### PR TITLE
Added wireshark-gtk, weechat, and hexchat

### DIFF
--- a/roles/csg-session/tasks/main.yml
+++ b/roles/csg-session/tasks/main.yml
@@ -14,6 +14,7 @@
     - file
     - firefox
     - git-all
+    - hexchat
     - libreoffice
     - openbsd-netcat
     - python-pip
@@ -21,8 +22,9 @@
     - virtualbox-ose
     - vlc
     - webcat
+    - weechat
     - wget
-    - wireshark
+    - wireshark-gtk
     - xtools
     - xxd
 


### PR DESCRIPTION
Swapped wireshark to wireshark-gtk, as most users prefer the graphical interface.
Added weechat and hexchat to allow lab users to utilize IRC.
